### PR TITLE
GT: Support PVT stage revision ID

### DIFF
--- a/meta-facebook/gt-cc/src/platform/plat_class.h
+++ b/meta-facebook/gt-cc/src/platform/plat_class.h
@@ -31,7 +31,7 @@ typedef enum {
 	GT_STAGE_EVT = 1,
 	GT_STAGE_EVT2 = 2,
 	GT_STAGE_DVT = 3,
-	GT_STAGE_DVT2 = 4,
+	GT_STAGE_PVT = 4,
 } GT_STAGE_REVISION_ID;
 
 typedef enum {


### PR DESCRIPTION
Summary:
- Support PVT stage revision ID to load sensor table.
- If current stage is not support, use PVT as default.

Test Plan:
- Build code: Pass