### PR TITLE
Common:MCTP: Add buffer for MCTP message

### DIFF
--- a/common/service/mctp/mctp.h
+++ b/common/service/mctp/mctp.h
@@ -171,11 +171,11 @@ typedef struct _mctp {
 	/* write queue */
 	struct k_msgq mctp_tx_queue;
 
-	/* point to the rx message buffer that is assembling */
+	/* point to the rx message buffer that is assembling request/response */
 	struct {
 		uint8_t *buf;
 		uint16_t offset;
-	} temp_msg_buf[MCTP_MAX_MSG_TAG_NUM];
+	} temp_msg_buf[MCTP_MAX_MSG_TAG_NUM][2];
 
 	/* the callback when recevie mctp data */
 	mctp_fn_cb rx_cb;


### PR DESCRIPTION
Summary:
- Add buffers for different message tags and message requests or responses distinguished by tag owner.

Test Plan:
- Build code: Pass